### PR TITLE
[REFACTOR] Moved pref loading and added data classes for config

### DIFF
--- a/app/src/main/java/com/enixcoda/smsforward/PreferencesLoader.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/PreferencesLoader.kt
@@ -1,0 +1,80 @@
+package com.enixcoda.smsforward
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+
+/**
+ * A class for loading forwarding service preferences from the shared preferences.
+ *
+ * @property context The context used to access the shared preferences.
+ */
+class PreferencesLoader(private val context: Context) {
+    private val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+    /**
+     * Loads the SMS preferences from the shared preferences.
+     *
+     * @return An instance of [SMSPreferences] containing the loaded preferences.
+     */
+    fun loadSMSPreferences(): SMSPreferences {
+        return SMSPreferences(
+            enableSMS = sharedPreferences.getBoolean(context.getString(R.string.key_enable_sms), false),
+            targetNumber = sharedPreferences.getString(context.getString(R.string.key_target_sms), "") ?: ""
+        )
+    }
+
+    /**
+     * Loads the Web preferences from the shared preferences.
+     *
+     * @return An instance of [WebPreferences] containing the loaded preferences.
+     */
+    fun loadWebPreferences(): WebPreferences {
+        return WebPreferences(
+            enableWeb = sharedPreferences.getBoolean(context.getString(R.string.key_enable_web), false),
+            targetWeb = sharedPreferences.getString(context.getString(R.string.key_target_web), "") ?: ""
+        )
+    }
+
+    /**
+     * Loads the Telegram preferences from the shared preferences.
+     *
+     * @return An instance of [TelegramPreferences] containing the loaded preferences.
+     */
+    fun loadTelegramPreferences(): TelegramPreferences {
+        return TelegramPreferences(
+            enableTelegram = sharedPreferences.getBoolean(context.getString(R.string.key_enable_telegram), false),
+            targetTelegram = sharedPreferences.getString(context.getString(R.string.key_target_telegram), "") ?: "",
+            telegramToken = sharedPreferences.getString(context.getString(R.string.key_telegram_apikey), "") ?: ""
+        )
+    }
+
+    /**
+     * Loads the RocketChat preferences from the shared preferences.
+     *
+     * @return An instance of [RocketChatPreferences] containing the loaded preferences.
+     */
+    fun loadRocketChatPreferences(): RocketChatPreferences {
+        return RocketChatPreferences(
+            enableRocketChat = sharedPreferences.getBoolean(context.getString(R.string.key_enable_rocket_chat), false),
+            rocketChatBaseUrl = sharedPreferences.getString(context.getString(R.string.key_rocket_chat_base_url), "") ?: "",
+            rocketChatUserId = sharedPreferences.getString(context.getString(R.string.key_rocket_chat_user_id), "") ?: "",
+            rocketChatToken = sharedPreferences.getString(context.getString(R.string.key_rocket_chat_auth_key), "") ?: "",
+            rocketChatChannel = sharedPreferences.getString(context.getString(R.string.key_rocket_chat_channel), "") ?: ""
+        )
+    }
+
+    /**
+     * Loads the Twilio preferences from the shared preferences.
+     *
+     * @return An instance of [TwilioPreferences] containing the loaded preferences.
+     */
+    fun loadTwilioPreferences(): TwilioPreferences {
+        return TwilioPreferences(
+            enableTwilio = sharedPreferences.getBoolean(context.getString(R.string.key_enable_twilio), false),
+            twilioAccountSid = sharedPreferences.getString(context.getString(R.string.key_twilio_account_sid), "") ?: "",
+            twilioAuthToken = sharedPreferences.getString(context.getString(R.string.key_twilio_auth_token), "") ?: "",
+            twilioFromNumber = sharedPreferences.getString(context.getString(R.string.key_twilio_from), "") ?: "",
+            twilioToNumber = sharedPreferences.getString(context.getString(R.string.key_twilio_to), "") ?: ""
+        )
+    }
+}

--- a/app/src/main/java/com/enixcoda/smsforward/ServicePreferences.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/ServicePreferences.kt
@@ -1,0 +1,123 @@
+package com.enixcoda.smsforward
+
+/**
+ * Data class representing SMS preferences.
+ *
+ * @property enableSMS Boolean indicating if SMS is enabled.
+ * @property targetNumber The target phone number for SMS.
+ */
+data class SMSPreferences(
+    val enableSMS: Boolean,
+    val targetNumber: String
+) {
+    /**
+     * Checks if SMS preferences are valid.
+     *
+     * @return Boolean indicating if SMS preferences are valid.
+     */
+    fun isValid(): Boolean {
+        return enableSMS && targetNumber.isNotEmpty()
+    }
+}
+
+/**
+ * Data class representing Web preferences.
+ *
+ * @property enableWeb Boolean indicating if Web is enabled.
+ * @property targetWeb The target URL for Web.
+ */
+data class WebPreferences(
+    val enableWeb: Boolean,
+    val targetWeb: String
+) {
+    /**
+     * Checks if Web preferences are valid.
+     *
+     * @return Boolean indicating if Web preferences are valid.
+     */
+    fun isValid(): Boolean {
+        return enableWeb && targetWeb.isNotEmpty()
+    }
+}
+
+/**
+ * Data class representing Telegram preferences.
+ *
+ * @property enableTelegram Boolean indicating if Telegram is enabled.
+ * @property targetTelegram The target Telegram ID.
+ * @property telegramToken The API token for Telegram.
+ */
+data class TelegramPreferences(
+    val enableTelegram: Boolean,
+    val targetTelegram: String,
+    val telegramToken: String
+) {
+    /**
+     * Checks if Telegram preferences are valid.
+     *
+     * @return Boolean indicating if Telegram preferences are valid.
+     */
+    fun isValid(): Boolean {
+        return enableTelegram && targetTelegram.isNotEmpty() && telegramToken.isNotEmpty()
+    }
+}
+
+/**
+ * Data class representing RocketChat preferences.
+ *
+ * @property enableRocketChat Boolean indicating if RocketChat is enabled.
+ * @property rocketChatBaseUrl The base URL for RocketChat.
+ * @property rocketChatUserId The user ID for RocketChat.
+ * @property rocketChatToken The authentication token for RocketChat.
+ * @property rocketChatChannel The channel name for RocketChat.
+ */
+data class RocketChatPreferences(
+    val enableRocketChat: Boolean,
+    val rocketChatBaseUrl: String,
+    val rocketChatUserId: String,
+    val rocketChatToken: String,
+    val rocketChatChannel: String
+) {
+    /**
+     * Checks if RocketChat preferences are valid.
+     *
+     * @return Boolean indicating if RocketChat preferences are valid.
+     */
+    fun isValid(): Boolean {
+        return enableRocketChat &&
+                rocketChatBaseUrl.isNotEmpty() &&
+                rocketChatUserId.isNotEmpty() &&
+                rocketChatToken.isNotEmpty() &&
+                rocketChatChannel.isNotEmpty()
+    }
+}
+
+/**
+ * Data class representing Twilio preferences.
+ *
+ * @property enableTwilio Boolean indicating if Twilio is enabled.
+ * @property twilioAccountSid The account SID for Twilio.
+ * @property twilioAuthToken The authentication token for Twilio.
+ * @property twilioFromNumber The sender phone number for Twilio.
+ * @property twilioToNumber The recipient phone number for Twilio.
+ */
+data class TwilioPreferences(
+    val enableTwilio: Boolean,
+    val twilioAccountSid: String,
+    val twilioAuthToken: String,
+    val twilioFromNumber: String,
+    val twilioToNumber: String
+) {
+    /**
+     * Checks if Twilio preferences are valid.
+     *
+     * @return Boolean indicating if Twilio preferences are valid.
+     */
+    fun isValid(): Boolean {
+        return enableTwilio &&
+                twilioAccountSid.isNotEmpty() &&
+                twilioAuthToken.isNotEmpty() &&
+                twilioFromNumber.isNotEmpty() &&
+                twilioToNumber.isNotEmpty()
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `PreferencesLoader` class to manage the loading of various service preferences from shared preferences, and refactors the `SMSReceiver` class to utilize this new loader. Additionally, it adds several data classes to represent the different service preferences.

### New Class for Preferences Loading:

* [`app/src/main/java/com/enixcoda/smsforward/PreferencesLoader.kt`](diffhunk://#diff-ef516495c65e6e451360421969e25c1cc547470e2e15f23a96c9eac6b82bd9e6R1-R80): Introduced the `PreferencesLoader` class to encapsulate the logic for loading preferences for SMS, Web, Telegram, RocketChat, and Twilio services.

### Refactoring for Preferences Management:

* [`app/src/main/java/com/enixcoda/smsforward/SMSReceiver.java`](diffhunk://#diff-3aa1c9877d3b83e1583b080bde54eed79e63ac63f83eeef525f63bd8829eadd2L20-R34): Refactored the `onReceive` method to use the `PreferencesLoader` for loading preferences, replacing direct access to shared preferences. This change simplifies the code and improves readability. [[1]](diffhunk://#diff-3aa1c9877d3b83e1583b080bde54eed79e63ac63f83eeef525f63bd8829eadd2L20-R34) [[2]](diffhunk://#diff-3aa1c9877d3b83e1583b080bde54eed79e63ac63f83eeef525f63bd8829eadd2L66-R50) [[3]](diffhunk://#diff-3aa1c9877d3b83e1583b080bde54eed79e63ac63f83eeef525f63bd8829eadd2L76-R82)

### New Data Classes for Preferences:

* [`app/src/main/java/com/enixcoda/smsforward/ServicePreferences.kt`](diffhunk://#diff-fa1883fa8b0848508f6c9d3d1d28362d32a3a02b86937283d4149ea625fb8c96R1-R123): Added data classes `SMSPreferences`, `WebPreferences`, `TelegramPreferences`, `RocketChatPreferences`, and `TwilioPreferences` to represent the preferences for each service. Each class includes an `isValid` method to check the validity of the preferences.