### PR TITLE
Add email forwarder

### DIFF
--- a/app/src/main/java/com/enixcoda/smsforward/ForwardTaskForEmail.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/ForwardTaskForEmail.kt
@@ -1,6 +1,9 @@
 package com.enixcoda.smsforward
 
 import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.Properties
 import javax.mail.Message
 import javax.mail.MessagingException
@@ -40,10 +43,10 @@ class ForwardTaskForEmail(
             put("mail.smtp.host", smtpHost)
             put("mail.smtp.port", smtpPort)
             put("mail.smtp.auth", "true")
-            put("mail.smtp.connectiontimeout", "10000");
-            put("mail.smtp.timeout", "10000");
-            put("mail.smtp.writetimeout", "10000");
-            put("mail.smtp.allow8bitmime", "true");
+            put("mail.smtp.connectiontimeout", "10000")
+            put("mail.smtp.timeout", "10000")
+            put("mail.smtp.writetimeout", "10000")
+            put("mail.smtp.allow8bitmime", "true")
             put("mail.smtp.starttls.enable", "true")
         }
 
@@ -53,18 +56,20 @@ class ForwardTaskForEmail(
             }
         })
 
-        try {
-            val message = MimeMessage(session).apply {
-                setFrom(InternetAddress(fromEmail))
-                setRecipients(Message.RecipientType.TO, InternetAddress.parse(toEmail))
-                subject = emailSubject
-                setText(emailBody)
-            }
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val message = MimeMessage(session).apply {
+                    setFrom(InternetAddress(fromEmail))
+                    setRecipients(Message.RecipientType.TO, InternetAddress.parse(toEmail))
+                    subject = emailSubject
+                    setText(emailBody)
+                }
 
-            Transport.send(message)
-            Log.d("EmailTask", "Email sent successfully.")
-        } catch (e: MessagingException) {
-            Log.e("EmailTask", "Failed to send email: ${e.message}", e)
+                Transport.send(message)
+                Log.d("EmailTask", "Email sent successfully.")
+            } catch (e: MessagingException) {
+                Log.e("EmailTask", "Failed to send email: ${e.message}", e)
+            }
         }
     }
 }

--- a/app/src/main/java/com/enixcoda/smsforward/ForwardTaskForEmail.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/ForwardTaskForEmail.kt
@@ -1,0 +1,66 @@
+package com.enixcoda.smsforward
+
+import android.util.Log
+import java.util.Properties
+import javax.mail.Message
+import javax.mail.MessagingException
+import javax.mail.PasswordAuthentication
+import javax.mail.Session
+import javax.mail.Transport
+import javax.mail.internet.InternetAddress
+import javax.mail.internet.MimeMessage
+
+/**
+ * A class to handle the task of forwarding an email.
+ *
+ * @property smtpHost The SMTP server host.
+ * @property smtpPort The SMTP server port.
+ * @property smtpUser The SMTP server username.
+ * @property smtpPassword The SMTP server password.
+ * @property fromEmail The email address from which the email is sent.
+ * @property toEmail The email address to which the email is sent.
+ * @property subject The subject of the email.
+ * @property body The body content of the email.
+ */
+class ForwardTaskForEmail(
+    private val smtpHost: String,
+    private val smtpPort: String,
+    private val smtpUser: String,
+    private val smtpPassword: String,
+    private val fromEmail: String,
+    private val toEmail: String,
+    private val subject: String,
+    private val body: String
+) {
+    /**
+     * Sends the email using the provided SMTP server details.
+     */
+    fun send() {
+        val properties = Properties().apply {
+            put("mail.smtp.host", smtpHost)
+            put("mail.smtp.port", smtpPort)
+            put("mail.smtp.auth", "true")
+            put("mail.smtp.starttls.enable", "true")
+        }
+
+        val session = Session.getInstance(properties, object : javax.mail.Authenticator() {
+            override fun getPasswordAuthentication(): PasswordAuthentication {
+                return PasswordAuthentication(smtpUser, smtpPassword)
+            }
+        })
+
+        try {
+            val message = MimeMessage(session).apply {
+                setFrom(InternetAddress(fromEmail))
+                setRecipients(Message.RecipientType.TO, InternetAddress.parse(toEmail))
+                subject = this@ForwardTaskForEmail.subject
+                setText(body)
+            }
+
+            Transport.send(message)
+            Log.d("EmailTask", "Email sent successfully.")
+        } catch (e: MessagingException) {
+            Log.e("EmailTask", "Failed to send email: ${e.message}", e)
+        }
+    }
+}

--- a/app/src/main/java/com/enixcoda/smsforward/ForwardTaskForEmail.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/ForwardTaskForEmail.kt
@@ -19,8 +19,8 @@ import javax.mail.internet.MimeMessage
  * @property smtpPassword The SMTP server password.
  * @property fromEmail The email address from which the email is sent.
  * @property toEmail The email address to which the email is sent.
- * @property subject The subject of the email.
- * @property body The body content of the email.
+ * @property emailSubject The subject of the email.
+ * @property emailBody The body content of the email.
  */
 class ForwardTaskForEmail(
     private val smtpHost: String,
@@ -29,8 +29,8 @@ class ForwardTaskForEmail(
     private val smtpPassword: String,
     private val fromEmail: String,
     private val toEmail: String,
-    private val subject: String,
-    private val body: String
+    private val emailSubject: String,
+    private val emailBody: String
 ) {
     /**
      * Sends the email using the provided SMTP server details.
@@ -40,6 +40,10 @@ class ForwardTaskForEmail(
             put("mail.smtp.host", smtpHost)
             put("mail.smtp.port", smtpPort)
             put("mail.smtp.auth", "true")
+            put("mail.smtp.connectiontimeout", "10000");
+            put("mail.smtp.timeout", "10000");
+            put("mail.smtp.writetimeout", "10000");
+            put("mail.smtp.allow8bitmime", "true");
             put("mail.smtp.starttls.enable", "true")
         }
 
@@ -53,8 +57,8 @@ class ForwardTaskForEmail(
             val message = MimeMessage(session).apply {
                 setFrom(InternetAddress(fromEmail))
                 setRecipients(Message.RecipientType.TO, InternetAddress.parse(toEmail))
-                subject = this@ForwardTaskForEmail.subject
-                setText(body)
+                subject = emailSubject
+                setText(emailBody)
             }
 
             Transport.send(message)

--- a/app/src/main/java/com/enixcoda/smsforward/Forwarder.java
+++ b/app/src/main/java/com/enixcoda/smsforward/Forwarder.java
@@ -44,4 +44,17 @@ public class Forwarder {
     public static void forwardViaWeb(String senderNumber, String message, String endpoint) {
         new ForwardTaskForWeb(senderNumber, message, endpoint).send();
     }
+
+    public static void forwardViaEmail(String senderNumber, String message, EmailPreferences emailPref) {
+        new ForwardTaskForEmail(
+                emailPref.getSmtpHost(),
+                emailPref.getSmtpPort(),
+                emailPref.getSmtpUser(),
+                emailPref.getSmtpPassword(),
+                emailPref.getFromEmail(),
+                emailPref.getToEmail(),
+                "Forwarded SMS message from " + senderNumber,
+                message
+        ).send();
+    }
 }

--- a/app/src/main/java/com/enixcoda/smsforward/MainActivity.java
+++ b/app/src/main/java/com/enixcoda/smsforward/MainActivity.java
@@ -35,6 +35,24 @@ public class MainActivity extends AppCompatActivity {
         }
 
         checkDefaultSmsApp();
+
+        //testForwarding();
+    }
+
+    /**
+     * Test forwarding SMS to the target destination.
+     */
+    private void testForwarding() {
+        if(BuildConfig.DEBUG) {
+            Log.d("MainActivity", "testForwarding: Testing forwarding");
+        } else {
+            return;
+        }
+
+        PreferencesLoader preferencesLoader = new PreferencesLoader(this);
+        EmailPreferences emailPreferences = preferencesLoader.loadEmailPreferences();
+
+        Forwarder.forwardViaEmail("1234567890", "Test message", emailPreferences);
     }
 
     public void requestRequiredPermissions() {

--- a/app/src/main/java/com/enixcoda/smsforward/MainActivity.java
+++ b/app/src/main/java/com/enixcoda/smsforward/MainActivity.java
@@ -97,6 +97,13 @@ public class MainActivity extends AppCompatActivity {
             updateValues(R.string.key_twilio_auth_token, R.string.key_twilio_auth_token_summary);
             updateValues(R.string.key_twilio_from, R.string.key_twilio_from_title);
             updateValues(R.string.key_twilio_to, R.string.key_twilio_to_title);
+
+            // Preview Email values
+            updateValues(R.string.key_smtp_host, R.string.key_smtp_host_summary);
+            updateValues(R.string.key_smtp_port, R.string.key_smtp_port_summary);
+            updateValues(R.string.key_smtp_user, R.string.key_smtp_user_summary);
+            updateValues(R.string.key_from_email, R.string.key_from_email_summary);
+            updateValues(R.string.key_to_email, R.string.key_to_email_summary);
         }
 
         /**

--- a/app/src/main/java/com/enixcoda/smsforward/MainActivity.java
+++ b/app/src/main/java/com/enixcoda/smsforward/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends AppCompatActivity {
      * Test forwarding SMS to the target destination.
      */
     private void testForwarding() {
-        if(BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG) {
             Log.d("MainActivity", "testForwarding: Testing forwarding");
         } else {
             return;
@@ -52,7 +52,9 @@ public class MainActivity extends AppCompatActivity {
         PreferencesLoader preferencesLoader = new PreferencesLoader(this);
         EmailPreferences emailPreferences = preferencesLoader.loadEmailPreferences();
 
-        Forwarder.forwardViaEmail("1234567890", "Test message", emailPreferences);
+        if (emailPreferences.isValid()) {
+            Forwarder.forwardViaEmail("1234567890", "Test message", emailPreferences);
+        }
     }
 
     public void requestRequiredPermissions() {

--- a/app/src/main/java/com/enixcoda/smsforward/PreferencesLoader.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/PreferencesLoader.kt
@@ -77,4 +77,21 @@ class PreferencesLoader(private val context: Context) {
             twilioToNumber = sharedPreferences.getString(context.getString(R.string.key_twilio_to), "") ?: ""
         )
     }
+
+    /**
+     * Loads the Email preferences from the shared preferences.
+     *
+     * @return An instance of [EmailPreferences] containing the loaded preferences.
+     */
+    fun loadEmailPreferences(): EmailPreferences {
+        return EmailPreferences(
+            enableEmail = sharedPreferences.getBoolean(context.getString(R.string.key_enable_email), false),
+            smtpHost = sharedPreferences.getString(context.getString(R.string.key_smtp_host), "") ?: "",
+            smtpPort = sharedPreferences.getString(context.getString(R.string.key_smtp_port), "") ?: "",
+            smtpUser = sharedPreferences.getString(context.getString(R.string.key_smtp_user), "") ?: "",
+            smtpPassword = sharedPreferences.getString(context.getString(R.string.key_smtp_password), "") ?: "",
+            fromEmail = sharedPreferences.getString(context.getString(R.string.key_from_email), "") ?: "",
+            toEmail = sharedPreferences.getString(context.getString(R.string.key_to_email), "") ?: ""
+        )
+    }
 }

--- a/app/src/main/java/com/enixcoda/smsforward/SMSReceiver.java
+++ b/app/src/main/java/com/enixcoda/smsforward/SMSReceiver.java
@@ -9,8 +9,18 @@ import android.util.Log;
 
 import androidx.annotation.Keep;
 
+/**
+ * BroadcastReceiver to handle incoming SMS messages and forward them via various methods.
+ */
 @Keep
 public class SMSReceiver extends BroadcastReceiver {
+
+    /**
+     * Called when an SMS message is received.
+     *
+     * @param context The Context in which the receiver is running.
+     * @param intent  The Intent being received.
+     */
     @Override
     public void onReceive(Context context, Intent intent) {
         Log.d("SMSReceiver", "onReceive: action " + intent.getAction());
@@ -24,12 +34,14 @@ public class SMSReceiver extends BroadcastReceiver {
         TelegramPreferences telegramPreferences = preferencesLoader.loadTelegramPreferences();
         RocketChatPreferences rocketChatPreferences = preferencesLoader.loadRocketChatPreferences();
         TwilioPreferences twilioPreferences = preferencesLoader.loadTwilioPreferences();
+        EmailPreferences emailPreferences = preferencesLoader.loadEmailPreferences();
 
         Log.d("SMSReceiver", "onReceive: enableSMS = " + smsPreferences.getEnableSMS());
         Log.d("SMSReceiver", "onReceive: enableTelegram = " + telegramPreferences.getEnableTelegram());
         Log.d("SMSReceiver", "onReceive: enableRocketChat = " + rocketChatPreferences.getEnableRocketChat());
         Log.d("SMSReceiver", "onReceive: enableWeb = " + webPreferences.getEnableWeb());
         Log.d("SMSReceiver", "onReceive: enableTwilio = " + twilioPreferences.getEnableTwilio());
+        Log.d("SMSReceiver", "onReceive: enableEmail = " + emailPreferences.getEnableEmail());
 
         if (!smsPreferences.getEnableSMS() && !telegramPreferences.getEnableTelegram() && !rocketChatPreferences.getEnableRocketChat() && !webPreferences.getEnableWeb() && !twilioPreferences.getEnableTwilio()) {
             Log.d("SMSReceiver", "onReceive: SMS Forwarding is disabled");
@@ -56,7 +68,8 @@ public class SMSReceiver extends BroadcastReceiver {
                     Forwarder.sendSMS(forwardNumber, forwardContent);
                 }
             } else {
-                // normal message, forwarded
+                // normal message, forward via all enabled methods
+
                 if (smsPreferences.isValid()) {
                     Log.d("SMSReceiver", "onReceive: Forwarding SMS to " + smsPreferences.getTargetNumber());
                     Forwarder.forwardViaSMS(senderNumber, rawMessageContent, smsPreferences.getTargetNumber());
@@ -80,6 +93,11 @@ public class SMSReceiver extends BroadcastReceiver {
                 if (webPreferences.isValid()) {
                     Log.d("SMSReceiver", "onReceive: Forwarding Web to " + webPreferences.getTargetWeb());
                     Forwarder.forwardViaWeb(senderNumber, rawMessageContent, webPreferences.getTargetWeb());
+                }
+
+                if (webPreferences.isValid()) {
+                    Log.d("SMSReceiver", "onReceive: Forwarding Email to " + emailPreferences.getToEmail());
+                    Forwarder.forwardViaEmail(senderNumber, rawMessageContent, emailPreferences);
                 }
             }
         }

--- a/app/src/main/java/com/enixcoda/smsforward/ServicePreferences.kt
+++ b/app/src/main/java/com/enixcoda/smsforward/ServicePreferences.kt
@@ -121,3 +121,39 @@ data class TwilioPreferences(
                 twilioToNumber.isNotEmpty()
     }
 }
+
+/**
+ * Data class representing Email preferences.
+ *
+ * @property enableEmail Boolean indicating if Email is enabled.
+ * @property smtpHost The SMTP host for Email.
+ * @property smtpPort The SMTP port for Email.
+ * @property smtpUser The SMTP user for Email.
+ * @property smtpPassword The SMTP password for Email.
+ * @property fromEmail The sender email address.
+ * @property toEmail The recipient email address.
+ */
+data class EmailPreferences(
+    val enableEmail: Boolean,
+    val smtpHost: String,
+    val smtpPort: String,
+    val smtpUser: String,
+    val smtpPassword: String,
+    val fromEmail: String,
+    val toEmail: String
+) {
+    /**
+     * Checks if Email preferences are valid.
+     *
+     * @return Boolean indicating if Email preferences are valid.
+     */
+    fun isValid(): Boolean {
+        return enableEmail &&
+                smtpHost.isNotEmpty() &&
+                smtpPort.isNotEmpty() &&
+                smtpUser.isNotEmpty() &&
+                smtpPassword.isNotEmpty() &&
+                fromEmail.isNotEmpty() &&
+                toEmail.isNotEmpty()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,4 +57,28 @@
     <string name="key_target_web">key_target_web</string>
     <string name="target_title_web">Target Web URL</string>
     <string name="target_summary_web">Example: https://site.com/api\nThis app will send POST request on receive SMS, request body example:\n{ "from": "10000", "message": "Hello" }</string>
+
+    <!-- Email -->
+    <string name="key_enable_email">key_enable_email</string>
+    <string name="header_email">Forward via Email</string>
+    <string name="enable_email">Enable Email</string>
+    <string name="key_smtp_host">key_smtp_host</string>
+    <string name="key_smtp_host_title">SMTP Host</string>
+    <string name="key_smtp_host_summary">Eg. smtp.gmail.com</string>
+    <string name="key_smtp_port">key_smtp_port</string>
+    <string name="key_smtp_port_title">SMTP Port</string>
+    <string name="key_smtp_port_summary">Eg. 587</string>
+    <string name="key_smtp_user">key_smtp_user</string>
+    <string name="key_smtp_user_title">SMTP User</string>
+    <string name="key_smtp_user_summary">Eg. user@email.com</string>
+    <string name="key_smtp_password">key_smtp_password</string>
+    <string name="key_smtp_password_title">SMTP Password</string>
+    <string name="key_smtp_password_summary">Eg. password</string>
+    <string name="key_from_email">key_from_email</string>
+    <string name="key_from_email_title">From Email</string>
+    <string name="key_from_email_summary">Eg. me@email.com</string>
+    <string name="key_to_email">key_to_email</string>
+    <string name="key_to_email_title">To Email</string>
+    <string name="key_to_email_summary">Eg. destination@email.com</string>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -152,4 +152,66 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        app:title="@string/header_email"
+        app:iconSpaceReserved="false">
+
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="false"
+            android:key="@string/key_enable_email"
+            app:title="@string/enable_email" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/key_smtp_host"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/key_smtp_host_title"
+            app:summary="@string/key_smtp_host_summary"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/key_smtp_port"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:inputType="number"
+            android:title="@string/key_smtp_port_title"
+            app:summary="@string/key_smtp_port_summary"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/key_smtp_user"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/key_smtp_user_title"
+            app:summary="@string/key_smtp_user_summary"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/key_smtp_password"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:inputType="textPassword"
+            android:title="@string/key_smtp_password_title"
+            app:summary="@string/key_smtp_password_summary"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/key_from_email"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:inputType="textEmailAddress"
+            android:title="@string/key_from_email_title"
+            app:summary="@string/key_from_email_summary"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/key_to_email"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:inputType="textEmailAddress"
+            android:title="@string/key_to_email_title"
+            app:summary="@string/key_to_email_summary"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
This pull request introduces the functionality to forward SMS messages via email in the `smsforward` application. The changes include adding a new class for handling email forwarding, updating the preferences to include email settings, and modifying existing classes to support the new email forwarding feature.

### Email Forwarding Feature:

* **New Class for Email Forwarding**:
  * Added `ForwardTaskForEmail` class to handle the task of forwarding an email using SMTP server details.

* **Integration with Existing Forwarding Methods**:
  * Updated `Forwarder` class to include a new method `forwardViaEmail` for forwarding SMS messages via email.
  * Modified `SMSReceiver` to load email preferences and forward SMS messages via email if enabled. [[1]](diffhunk://#diff-3aa1c9877d3b83e1583b080bde54eed79e63ac63f83eeef525f63bd8829eadd2R37-R44) [[2]](diffhunk://#diff-3aa1c9877d3b83e1583b080bde54eed79e63ac63f83eeef525f63bd8829eadd2R97-R101)

* **Preferences and Settings**:
  * Added email-related preferences in `PreferencesLoader` to load SMTP details and email addresses.
  * Updated `MainActivity` to include email settings in the preferences screen and added a method for testing email forwarding. [[1]](diffhunk://#diff-4ac4d1e2d4e2b82bb631b44518a8b1be4a5e22177a61ed3bf52def8cfb7f2d2bR38-R57) [[2]](diffhunk://#diff-4ac4d1e2d4e2b82bb631b44518a8b1be4a5e22177a61ed3bf52def8cfb7f2d2bR120-R126)
  * Included new email preference keys and summaries in `strings.xml`.
  * Added email preferences to the `root_preferences.xml` to enable users to configure email settings.

* **Data Classes**:
  * Introduced `EmailPreferences` data class to store email configuration details and validate them.

These changes collectively enable the application to forward SMS messages via email, providing users with an additional method for SMS forwarding.

<img width="756" alt="Screenshot 2024-12-07 at 6 00 02 PM" src="https://github.com/user-attachments/assets/5fa9c7d2-dec4-4e75-9b07-4a6c5072bf98">
